### PR TITLE
Fix protobuf JSON recursion depth bypass vulnerability

### DIFF
--- a/mlu-mlta/Labs/05-M1-Lab5_AutoGluon3/requirements.txt
+++ b/mlu-mlta/Labs/05-M1-Lab5_AutoGluon3/requirements.txt
@@ -3,4 +3,4 @@ pandas>=2.0.0,<2.3.0
 scikit-learn>=1.4.0,<1.5.3
 scipy>=1.7.2,<1.16
 spacy>=3.7.0,<3.8
-protobuf>=3.19.4,<5.0
+protobuf>=5.29.3


### PR DESCRIPTION
Fixes Dependabot alert #172: protobuf affected by a JSON recursion depth bypass (High)

Updated `mlu-mlta/Labs/05-M1-Lab5_AutoGluon3/requirements.txt`: protobuf from `>=3.19.4,<5.0` to `>=5.29.3`

Notebook tested and verified to run successfully after the change.